### PR TITLE
Add vocs file for surrogate model

### DIFF
--- a/surrogate_vocs.yaml
+++ b/surrogate_vocs.yaml
@@ -1,0 +1,28 @@
+variables:
+  Imain: [180.0, 260.0]  # in A
+  Ibuck: [500.0, 550.0]  # in A
+  gun_phase: [-40.7588, 39.2412]  # in deg
+  gun_inj_amp: [60.0, 65.0]  # in MV
+  Linacphase: [-30.0, 30.0]  # in deg
+  DQ4: [-5.0, 5.0]  # in T/m
+  DQ5: [-5.0, 5.0]  # in T/m
+  DQ6: [-5.0, 5.0]  # in T/m
+  DQ7: [-5.0, 5.0]  # in T/m
+constraints:
+  numParticles: [GREATER_THAN, 259522.0]  # less than 1% loss
+objectives: {rms_xy in m: MINIMIZE}
+constants: {}
+linked_variables: {}
+
+# Defaults: 
+#   Imain: 230 A
+#   Ibuck: 550 A
+#   gun_phase: -0.7588 deg
+#   gun_inj_amp: 61.26 MV
+#   Linacphase: 0.0 deg
+#   DQ4: 0.000000001 T/m
+#   DQ5: 0.000000001 T/m
+#   DQ6: 0.000000001 T/m
+#   DQ7: 0.000000001 T/m
+
+# Bunch charge: 1 nC


### PR DESCRIPTION
Adds a file to specify the Bayesian exploration task for the surrogate model in a centralized way.